### PR TITLE
do-like p/wrap for blocking code

### DIFF
--- a/scratch/ui_components.cljc
+++ b/scratch/ui_components.cljc
@@ -33,23 +33,23 @@
     [:hr]
     [:h2 "Button with pending state"]
 
-    (let [event (ui/button {::ui/click-event (p/fn [e] (p/server (p/wrap run-long-task!)))
-                            ::ui/pending {::dom/disabled true}}
+    (let [event (ui/button {::ui/click-event (p/fn [e] (p/server (p/wrap (run-long-task!))))
+                            ::ui/pending     {::dom/disabled true}}
                   (dom/text "Long running task (log to console)"))]
       (prn "clicked! " event))
 
     [:h2 "Button with cancelable pending state"]
 
     (let [event (ui/button {;; Won’t fire if element is aria-disabled or an descendant of an aria disabled
-                            ::ui/click-event (p/fn [event] (p/server (p/wrap run-long-task!)))
-                            ::ui/pending {;; These props are set when button enters pending state
-                                          ::dom/aria-busy     true
-                                          ::dom/aria-disabled true
-                                          ::ui/click-event    (p/fn [_] [::ui/cancel true])
-                                          ::ui/keychords      #{"esc"}
-                                          ;; This event will fire even if the element is aria-disabled
-                                          ::ui/keychord-event (p/fn [_] [::ui/cancel true])  ; cancel pending state
-                                          }}
+                            ::ui/click-event (p/fn [event] (p/server (p/wrap (run-long-task!))))
+                            ::ui/pending     {;; These props are set when button enters pending state
+                                              ::dom/aria-busy     true
+                                              ::dom/aria-disabled true
+                                              ::ui/click-event    (p/fn [_] [::ui/cancel true])
+                                              ::ui/keychords      #{"esc"}
+                                              ;; This event will fire even if the element is aria-disabled
+                                              ::ui/keychord-event (p/fn [_] [::ui/cancel true])  ; cancel pending state
+                                              }}
                   (dom/text "Long running task (log to console)"))]
       (prn "clicked! 2 " event))
 

--- a/src/hyperfiddle/photon.cljc
+++ b/src/hyperfiddle/photon.cljc
@@ -149,15 +149,16 @@ running on a remote host.
   ;; L: terminating a continuous flow means the value won't change anymore, so that's OK
   `(new (current* (p/fn [] ~x))))
 
-(cc/defn wrap* [f & args]
+(cc/defn wrap* [thunk]
   #?(:clj
-     (->> (m/ap (m/? (m/via m/blk (apply f args))))
+     (->> (m/ap (m/? (m/via m/blk (thunk))))
           (m/reductions {} (Failure. (Pending.)))
           (m/relieve {}))))
 
-(defmacro wrap "Run blocking function (io-bound) on a threadpool"
-  [f & args]
-  `(new (wrap* ~f ~@args)))
+(defmacro wrap
+  "Run blocking body (io-bound) on a threadpool"
+  [& body]
+  `(new (wrap* (cc/fn [] ~@body))))
 
 (cc/defn ^:no-doc empty?
   "A task completing with true on first successful transfer of given flow, or false

--- a/test/hyperfiddle/photon_test.cljc
+++ b/test/hyperfiddle/photon_test.cljc
@@ -446,6 +446,13 @@
   % := 1
   % := 1)
 
+(tests
+  (with
+    (p/run
+      (p/wrap
+        ;; FIXME add blocking sleep
+        (tap :done)))
+    % := :done))
 
 (comment
   (rcf/set-timeout! 4000)
@@ -873,7 +880,7 @@
 
   (p/defn Foo [x !]
     (new (hook x !)))
-  
+
   (def !x (atom 0))
   (let [dispose
         (p/run (tap
@@ -1117,7 +1124,7 @@
   (p/run (tap (new (p/fn [] (binding [unbound1 1 unbound2 2] (+ unbound1 unbound2))))))
   % := 3)
 
-#?(:clj 
+#?(:clj
 (tests
   "understand how Clojure handles unbound vars"
   ; In Clojure,


### PR DESCRIPTION
I couldn't figure out how to add blocking IO into the rcf test block. I tried
- `(m/ap (m/? (m/sleep 10)))` 
- `(new (m/ap (m/? (m/sleep 10))))`
- `(p/task->cp (m/? (m/sleep 10)))`

all of which errored or blocked indefinitely, making the tests time out