### PR TITLE
dev: allow to exports clj-kondo config

### DIFF
--- a/resources/clj-kondo.exports/hyperfiddle/electric/config.edn
+++ b/resources/clj-kondo.exports/hyperfiddle/electric/config.edn
@@ -1,0 +1,6 @@
+{:lint-as {hyperfiddle.electric/def        clojure.core/def
+           hyperfiddle.electric/defn       clojure.core/defn
+           hyperfiddle.electric/for        clojure.core/for
+           hyperfiddle.electric/with-cycle clojure.core/let
+           hyperfiddle.electric/fn         clojure.core/fn}
+ :linters {:redundant-expression {:level :off}}}


### PR DESCRIPTION
## Context

When we use `electric` externaly, `clj-kondo` don't know how to lint some macros.

## Types of changes

What types of changes does your code introduce?
- Developer experience (add or update dev functionality)
