### PR TITLE
fix parser-class for keyword args

### DIFF
--- a/src/hyperfiddle/electric_dom2.cljc
+++ b/src/hyperfiddle/electric_dom2.cljc
@@ -138,7 +138,7 @@
 (defn parse-class [xs]
   (cond (string? xs) (parse-class (str/split xs #"\s+"))
         (keyword? xs) (parse-class (name xs))
-        (coll? xs)   (into [] (comp (filter string?) (remove str/blank?)) xs)
+        (coll? xs)   (into [] (comp (map name) (filter string?) (remove str/blank?)) xs)
         :else        nil))
 
 #?(:cljs

--- a/src/hyperfiddle/electric_dom2.cljc
+++ b/src/hyperfiddle/electric_dom2.cljc
@@ -137,6 +137,7 @@
 
 (defn parse-class [xs]
   (cond (string? xs) (parse-class (str/split xs #"\s+"))
+        (keyword? xs) (parse-class (name xs))
         (coll? xs)   (into [] (comp (filter string?) (remove str/blank?)) xs)
         :else        nil))
 


### PR DESCRIPTION
In the latest release, `dom/props` doesn't recognize keywords 